### PR TITLE
Better handle edge cases where ElementBlogPosts targets a missing blog page

### DIFF
--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -10,6 +10,7 @@ use SilverStripe\Blog\Model\BlogPost;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\RequiredFields;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\ValidationResult;
@@ -109,15 +110,20 @@ class ElementBlogPosts extends BaseElement
      */
     public function getPostsList()
     {
-        if ($this->BlogID) {
-            if ($this->CategoryID) {
-                return BlogCategory::get()->byID($this->CategoryID)->BlogPosts()->Limit($this->Limit);
-            }
-            return Blog::get()->byID($this->BlogID)->getBlogPosts()->Limit($this->Limit);
+        /** @var DataList $posts */
+        $posts = null;
+
+        if ($this->BlogID && $this->CategoryID && $category = BlogCategory::get()->byID($this->CategoryID)) {
+            $posts = $category->BlogPosts();
+        } elseif ($this->BlogID && $blog = Blog::get()->byID($this->BlogID)) {
+            $posts = $blog->getBlogPosts();
         } else {
-            return BlogPost::get()->sort('PublishDate DESC')->limit($this->Limit);
+            $posts = BlogPost::get()->sort('PublishDate DESC');
         }
+
+        return $posts->limit($this->Limit);
     }
+
 
     /**
      * @return DBHTMLText

--- a/tests/Elements/ElementBlogPostsTest.php
+++ b/tests/Elements/ElementBlogPostsTest.php
@@ -4,9 +4,12 @@ namespace Dynamic\Elements\Blog\Elements\Tests;
 
 use Dynamic\Elements\Blog\Elements\ElementBlogPosts;
 use SilverStripe\Blog\Model\Blog;
+use SilverStripe\Blog\Model\BlogCategory;
 use SilverStripe\Blog\Model\BlogPost;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\SS_List;
 
 class ElementBlogPostsTest extends SapphireTest
 {
@@ -58,6 +61,45 @@ class ElementBlogPostsTest extends SapphireTest
     public function testGetPostsList()
     {
         $object = $this->objFromFixture(ElementBlogPosts::class, 'one');
-        $this->assertEquals($object->Blog()->getBlogPosts()->limit($object->Limit), $object->getPostsList());
+        $this->compareList(
+            $object->Blog()->getBlogPosts()->limit($object->Limit),
+            $object->getPostsList(),
+            'Should only return blog post assign to blog page'
+        );
+
+        $object = $this->objFromFixture(ElementBlogPosts::class, 'targetCategory');
+        $category = $this->objFromFixture(BlogCategory::class, 'category');
+        $this->compareList(
+            $category->BlogPosts()->limit($object->Limit),
+            $object->getPostsList(),
+            'Should only return blog post assign to blog category'
+        );
+
+        $object = $this->objFromFixture(ElementBlogPosts::class, 'noTarget');
+        $this->compareList(
+            BlogPost::get()->limit($object->Limit),
+            $object->getPostsList(),
+            'Should return all blog posts'
+        );
+
+        $object = $this->objFromFixture(ElementBlogPosts::class, 'badTarget');
+        $this->compareList(
+            BlogPost::get()->limit($object->Limit),
+            $object->getPostsList(),
+            'When ElementalBlogPost is misconfigured shoudl return all blog post'
+        );
+    }
+
+    /**
+     * Compare entries in $expected to entries in actual
+     * @param DataList $expected
+     * @param DataList $actual
+     * @param string $message
+     */
+    private function compareList(DataList $expected, DataList $actual, $message='')
+    {
+        $expectedArray = $expected->map('ID', 'ClassName')->toArray();
+        $actualArray = $expected->map('ID', 'ClassName')->toArray();
+        $this->assertEquals($expectedArray, $actualArray, $message);
     }
 }

--- a/tests/fixtures.yml
+++ b/tests/fixtures.yml
@@ -2,9 +2,41 @@ SilverStripe\Blog\Model\Blog:
   default:
     Title: "Blog"
 
+SilverStripe\Blog\Model\BlogCategory:
+  category:
+    Title: A Category
+    BlogID: =>SilverStripe\Blog\Model\Blog.default
+
+SilverStripe\Blog\Model\BlogPost:
+  orphan:
+    Title: Orphan blog post
+  noCategory:
+    Title: Blog post without a category
+    ParentID: =>SilverStripe\Blog\Model\Blog.default
+  withCategory:
+    Title: Blog post without a category
+    ParentID: =>SilverStripe\Blog\Model\Blog.default
+    Categories:
+     - =>SilverStripe\Blog\Model\BlogCategory.category
+
 Dynamic\Elements\Blog\Elements\ElementBlogPosts:
   one:
     Title: "Blog Posts"
     Limit: 3
     Content: "<p>Recent Posts</p>"
     BlogID: =>SilverStripe\Blog\Model\Blog.default
+  targetCategory:
+    Title: "Blog Posts"
+    Limit: 3
+    Content: "<p>Recent Posts</p>"
+    BlogID: =>SilverStripe\Blog\Model\Blog.default
+    CategoryID: =>SilverStripe\Blog\Model\BlogCategory.category
+  noTarget:
+    Title: "Blog Posts"
+    Limit: 3
+    Content: "<p>Recent Posts</p>"
+  badTarget:
+    Title: "Blog Posts"
+    Limit: 3
+    Content: "<p>Recent Posts</p>"
+    BlogID: 9999


### PR DESCRIPTION
The block assumes that the blog page will always exists, which may not be the case. For example:
* you could have a misconfiguration
* the blog page could be archived after the block has been created
* the blog page might not exists in the current locale

This PR makes the `getPostsList` logic more resilient and beefs up the matching test.