### PR TITLE
BUGFIX Call to a member function Categories() on null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,11 @@
         }
     },
     "config": {
-        "process-timeout": 600
+        "process-timeout": 600,
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -43,25 +43,25 @@ class ElementBlogPosts extends BaseElement
     /**
      * @var array
      */
-    private static $db = array(
+    private static $db = [
         'Limit' => 'Int',
         'Content' => 'HTMLText',
-    );
+    ];
 
     /**
      * @var array
      */
-    private static $has_one = array(
+    private static $has_one = [
         'Blog' => Blog::class,
         'Category' => BlogCategory::class,
-    );
+    ];
 
     /**
      * @var array
      */
-    private static $defaults = array(
+    private static $defaults = [
         'Limit' => 3,
-    );
+    ];
 
     /**
      * @return FieldList
@@ -85,7 +85,10 @@ class ElementBlogPosts extends BaseElement
 
                 $dataSource = function ($val) {
                     if ($val) {
-                        return Blog::get()->byID($val)->Categories()->map('ID', 'Title');
+                        if ($blog = Blog::get()->byID($val)) {
+                            return $blog->Categories()->map('ID', 'Title');
+                        }
+
                     }
                     return [];
                 };
@@ -137,7 +140,7 @@ class ElementBlogPosts extends BaseElement
         $label = _t(
             BlogPost::class . '.PLURALS',
             'A Blog Post|{count} Blog Posts',
-            [ 'count' => $count ]
+            ['count' => $count]
         );
         return DBField::create_field('HTMLText', $label)->Summary(20);
     }

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -88,7 +88,6 @@ class ElementBlogPosts extends BaseElement
                         if ($blog = Blog::get()->byID($val)) {
                             return $blog->Categories()->map('ID', 'Title');
                         }
-
                     }
                     return [];
                 };


### PR DESCRIPTION
Resolves an issue where no blog selected causes a chained `Categories()` relation call to error when attempting to edit the block later in the cms.

I haven't been able to build a proper test case that demonstrates the fix, however in local testing the cms now loads if no Blog is selected on an existing block.

resolves #38