### PR TITLE
MNT: Require PHP ^7.4 or ^8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "require": {
+        "php": "^7.4 || ^8.0",
         "silverstripe/blog": "^3.0",
         "dnadesign/silverstripe-elemental": "^4.8",
         "sheadawson/silverstripe-dependentdropdownfield": "^2.0"

--- a/src/Elements/ElementBlogOverview.php
+++ b/src/Elements/ElementBlogOverview.php
@@ -27,46 +27,26 @@ use SilverStripe\Widgets\Model\WidgetArea;
  */
 class ElementBlogOverview extends BaseElement
 {
-    /**
-     * @var array
-     */
-    private static $db = [
+    private static array $db = [
         'Content' => 'HTMLText',
         'ShowPagination' => 'Boolean(0)',
         'ShowWidgets' => 'Boolean(0)',
     ];
 
-    /**
-     * @var string
-     */
-    private static $icon = 'font-icon-p-articles';
+    private static string $icon = 'font-icon-p-articles';
 
-    /**
-     * @var string
-     */
-    private static $table_name = 'ElementBlogOverview';
+    private static string $table_name = 'ElementBlogOverview';
 
-    /**
-     * @var string
-     */
-    private static $singular_name = 'Element blog overview';
+    private static string $singular_name = 'Element blog overview';
 
-    /**
-     * @var string
-     */
-    private static $plural_name = 'Element blog overview blocks';
+    private static string $plural_name = 'Element blog overview blocks';
 
-    /**
-     * @var string
-     */
-    private static $description = 'Block displaying Blog Posts with pagination';
+    private static string $description = 'Block displaying Blog Posts with pagination';
 
     /**
      * We use this default_title for the Block name in the CMS. Feel free to update it via config
-     *
-     * @var string
      */
-    private static $default_title = 'Element Blog Overview';
+    private static string $default_title = 'Element Blog Overview';
 
     /**
      * The main purpose of this Block is to replace the standard Blog Layout functionality (including pagination,
@@ -76,81 +56,61 @@ class ElementBlogOverview extends BaseElement
      * By default, this Block will return null in all the areas where it expects to find a Blog/BlogController if it
      * does not. However, if you enable this Block to be used elsewhere, there are extension points/etc available for
      * you to return/update the DataList/Paginated list in other ways
-     *
-     * @var bool
      */
-    private static $allow_use_outside_of_blog = false;
+    private static bool $allow_use_outside_of_blog = false;
 
     /**
      * Depending on your config, there is potentially no reason for a content author to enter this Block to make any
      * edits, if that is the case for you, then it likely makes sense that you just set a title for them by default
-     *
-     * @var bool
      */
-    private static $set_default_title = false;
+    private static bool $set_default_title = false;
 
     /**
      * You can set this to false if you would prefer that we do not display the default Title field that Elemental
      * provides to users
-     *
-     * @var bool
      */
-    private static $show_title_field = true;
+    private static bool $show_title_field = true;
 
     /**
      * You can set this to false if you would prefer that we do not display the HTMLEditor/$Content field to users
-     *
-     * @var bool
      */
-    private static $show_content_field = true;
+    private static bool $show_content_field = true;
 
     /**
      * By default, we show the "Show Pagination" field in the CMS (since it is part of the default supported features).
      * You may, however, prefer that content authors display pagination for the Blog using the specific
      * `PaginationBlock`, and if that's the case, you'll likely want to set this to false via config, as it will no
      * longer be relevant for your content authors
-     *
-     * @var int
      */
-    private static $show_pagination_field = true;
+    private static bool $show_pagination_field = true;
 
     /**
      * Default value for ShowPagination. If set, this block will also output the pagination for your Blog. You can
      * update this value via config
-     *
-     * @var int
      */
-    private static $pagination_field_default = 1;
+    private static int $pagination_field_default = 1;
 
     /**
      * Since the Widgets module is an addon for the Blog module (and not out of the box), we've hidden the CMS field by
      * default. You can update this via config if you would like to display the field for your authors
-     *
-     * @var int
      */
-    private static $show_widgets_field = false;
+    private static bool $show_widgets_field = false;
 
     /**
      * Since the Widgets module is an addon for the Blog module (and not out of the box), we've set the default for this
      * field to be `0`. You can update this via config
-     *
-     * @var int
      */
-    private static $widgets_field_default = 0;
+    private static int $widgets_field_default = 0;
 
     /**
      * This can be updated via config if (for whatever reason) you do not wish to show this message field in the CMS
-     *
-     * @var int
      */
-    private static $show_info_message_field = true;
+    private static bool $show_info_message_field = true;
 
     /**
      * Default value used for the message field in the CMS
-     *
-     * @var string
      */
-    private static $info_message_field_default = 'This block will automatically display Blog Posts and pagination';
+    private static string $info_message_field_default = 'This block will automatically display Blog Posts and pagination';
 
     /**
      * Cached value for BlogPosts from the Blog page

--- a/src/Elements/ElementBlogOverview.php
+++ b/src/Elements/ElementBlogOverview.php
@@ -110,7 +110,7 @@ class ElementBlogOverview extends BaseElement
     /**
      * Default value used for the message field in the CMS
      */
-    private static string $info_message_field_default = 'This block will automatically display Blog Posts and pagination';
+    private static string $info_message_field_default = 'This block automatically displays Blog Posts and pagination';
 
     /**
      * Cached value for BlogPosts from the Blog page

--- a/src/Elements/ElementBlogPagination.php
+++ b/src/Elements/ElementBlogPagination.php
@@ -17,96 +17,59 @@ namespace Dynamic\Elements\Blog\Elements;
  */
 class ElementBlogPagination extends ElementBlogOverview
 {
-    /**
-     * @var string
-     */
-    private static $icon = 'font-icon-dot-3';
+    private static string $icon = 'font-icon-dot-3';
 
-    /**
-     * @var string
-     */
-    private static $table_name = 'ElementBlogPagination';
+    private static string $table_name = 'ElementBlogPagination';
 
-    /**
-     * @var string
-     */
-    private static $singular_name = 'Element blog pagination';
+    private static string $singular_name = 'Element blog pagination';
 
-    /**
-     * @var string
-     */
-    private static $plural_name = 'Element blog pagination blocks';
+    private static string $plural_name = 'Element blog pagination blocks';
 
-    /**
-     * @var string
-     */
-    private static $description = 'Block displaying pagination for Blog Posts';
+    private static string $description = 'Block displaying pagination for Blog Posts';
 
     /**
      * We use this default_title for the Block name in the CMS. Feel free to update it via config
-     *
-     * @var string
      */
-    private static $default_title = 'Element Blog Pagination';
+    private static string $default_title = 'Element Blog Pagination';
 
-    /**
-     * @var bool
-     */
-    private static $allow_use_outside_of_blog = false;
+    private static bool $allow_use_outside_of_blog = false;
 
     /**
      * OotB there is really no reason for a content author to enter this Block to make any edits, so, by default, we'll
      * just set a generic default Title. You can disable this via config
-     *
-     * @var bool
      */
-    private static $set_default_title = true;
+    private static bool $set_default_title = true;
 
     /**
      * This Block is intended to display pagination, so, hide this field by default
-     *
-     * @var bool
      */
-    private static $show_content_field = false;
+    private static bool $show_content_field = false;
 
     /**
      * This is the Pagination Block, we assume that we always want Pagination to be displayed (since that's all it will
      * display). So, no point in showing the CMS field to allow folks to toggle this on/off
-     *
-     * @var int
      */
-    private static $show_pagination_field = false;
+    private static bool $show_pagination_field = false;
 
-    /**
-     * @var int
-     */
-    private static $pagination_field_default = 1;
+    private static int $pagination_field_default = 1;
 
     /**
      * This Block is not intended to display widgets, so, hide this field by default
-     *
-     * @var int
      */
-    private static $show_widgets_field = false;
+    private static bool $show_widgets_field = false;
 
     /**
      * This Block is not intended to display widgets, so, set this to 0 by default
-     *
-     * @var int
      */
-    private static $widgets_field_default = 0;
+    private static int $widgets_field_default = 0;
 
     /**
      * This can be updated via config if (for whatever reason) you do not wish to show this message field in the CMS
-     *
-     * @var int
      */
-    private static $show_info_message_field = true;
+    private static bool $show_info_message_field = true;
 
     /**
      * Default value used for the message field in the CMS. You can update this via config
-     *
-     * @var string
      */
-    private static $info_message_field_default = 'This block will automatically display pagination for Blog Posts';
+    private static string $info_message_field_default = 'This block will automatically display pagination for Blog Posts';
 }

--- a/src/Elements/ElementBlogPagination.php
+++ b/src/Elements/ElementBlogPagination.php
@@ -71,5 +71,5 @@ class ElementBlogPagination extends ElementBlogOverview
     /**
      * Default value used for the message field in the CMS. You can update this via config
      */
-    private static string $info_message_field_default = 'This block will automatically display pagination for Blog Posts';
+    private static string $info_message_field_default = 'This block automatically displays pagination for Blog Posts';
 }

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -30,38 +30,29 @@ use SilverStripe\ORM\ValidationResult;
  */
 class ElementBlogPosts extends BaseElement
 {
-    /**
-     * @var string
-     */
-    private static $icon = 'font-icon-menu-campaigns';
+    private static string $icon = 'font-icon-menu-campaigns';
 
-    /**
-     * @var string
-     */
-    private static $table_name = 'ElementBlogPosts';
+    private static string $table_name = 'ElementBlogPosts';
 
-    /**
-     * @var array
-     */
-    private static $db = array(
+    private static array $db = [
         'Limit' => 'Int',
         'Content' => 'HTMLText',
-    );
+    ];
 
     /**
      * @var array
      */
-    private static $has_one = array(
+    private static array $has_one = [
         'Blog' => Blog::class,
         'Category' => BlogCategory::class,
-    );
+    ];
 
     /**
      * @var array
      */
-    private static $defaults = array(
+    private static array $defaults = [
         'Limit' => 3,
-    );
+    ];
 
     /**
      * @return FieldList

--- a/src/Elements/ElementBlogWidgets.php
+++ b/src/Elements/ElementBlogWidgets.php
@@ -17,98 +17,62 @@ namespace Dynamic\Elements\Blog\Elements;
  */
 class ElementBlogWidgets extends ElementBlogOverview
 {
-    /**
-     * @var string
-     */
-    private static $icon = 'font-icon-block-layout';
+    private static string $icon = 'font-icon-block-layout';
 
-    /**
-     * @var string
-     */
-    private static $table_name = 'ElementBlogWidgets';
+    private static string $table_name = 'ElementBlogWidgets';
 
-    /**
-     * @var string
-     */
-    private static $singular_name = 'Element blog widgets';
+    private static string $singular_name = 'Element blog widgets';
 
-    /**
-     * @var string
-     */
-    private static $plural_name = 'Element blog widget blocks';
+    private static string $plural_name = 'Element blog widget blocks';
 
-    /**
-     * @var string
-     */
-    private static $description = 'Block displaying Blog Widgets';
+    private static string $description = 'Block displaying Blog Widgets';
 
     /**
      * We use this default_title for the Block name in the CMS. Feel free to update it via config
-     *
-     * @var string
      */
-    private static $default_title = 'Blog Widgets';
+    private static string $default_title = 'Blog Widgets';
 
-    /**
-     * @var bool
-     */
-    private static $allow_use_outside_of_blog = false;
+    private static bool $allow_use_outside_of_blog = false;
 
     /**
      * OotB there is really no reason for a content author to enter this Block to make any edits, so, by default, we'll
      * just set a generic default Title. You can disable this via config
-     *
-     * @var bool
      */
-    private static $set_default_title = true;
+    private static bool $set_default_title = true;
 
     /**
      * This Block is intended to display widgets, so, hide this field by default
-     *
-     * @var bool
      */
-    private static $show_content_field = false;
+    private static bool $show_content_field = false;
 
     /**
      * This Block is not intended to display pagination, so, hide this field by default
-     *
-     * @var int
      */
-    private static $show_pagination_field = 0;
+    private static int $show_pagination_field = 0;
 
     /**
      * This Block is not intended to display pagination, so, set this to `0` by default
-     *
-     * @var int
      */
-    private static $pagination_field_default = 0;
+    private static int $pagination_field_default = 0;
 
     /**
      * This is the Widgets Block, we assume that we always want Widgets to be displayed. So, OotB there is no reason
      * to show the CMS field to allow folks to toggle this on/off
-     *
-     * @var int
      */
-    private static $show_widgets_field = 0;
+    private static int $show_widgets_field = 0;
 
     /**
      * We want Widgets to be displayed by default for this Block
-     *
-     * @var int
      */
-    private static $widgets_field_default = 1;
+    private static int $widgets_field_default = 1;
 
     /**
      * This can be updated via config if (for whatever reason) you do not wish to show this message field in the CMS
-     *
-     * @var int
      */
-    private static $show_info_message_field = 1;
+    private static int $show_info_message_field = 1;
 
     /**
      * Default value used for the message field in the CMS.
-     *
-     * @var string
      */
-    private static $info_message_field_default = 'This block will automatically display Blog Widgets';
+    private static string $info_message_field_default = 'This block will automatically display Blog Widgets';
 }

--- a/tests/Elements/ElementBlogPostsTest.php
+++ b/tests/Elements/ElementBlogPostsTest.php
@@ -19,7 +19,7 @@ class ElementBlogPostsTest extends SapphireTest
     /**
      *
      */
-    public function testGetSummary()
+    public function testGetSummary(): void
     {
         $object = $this->objFromFixture(ElementBlogPosts::class, 'one');
         $count = $object->getPostsList()->count();
@@ -36,7 +36,7 @@ class ElementBlogPostsTest extends SapphireTest
     /**
      *
      */
-    public function testGetType()
+    public function testGetType(): void
     {
         $object = $this->objFromFixture(ElementBlogPosts::class, 'one');
         $this->assertEquals($object->getType(), 'Blog Posts');
@@ -45,7 +45,7 @@ class ElementBlogPostsTest extends SapphireTest
     /**
      *
      */
-    public function testGetCMSFields()
+    public function testGetCMSFields(): void
     {
         $object = $this->objFromFixture(ElementBlogPosts::class, 'one');
         $fields = $object->getCMSFields();
@@ -56,7 +56,7 @@ class ElementBlogPostsTest extends SapphireTest
     /**
      *
      */
-    public function testGetPostsList()
+    public function testGetPostsList(): void
     {
         $object = $this->objFromFixture(ElementBlogPosts::class, 'one');
         $this->compareList(
@@ -94,7 +94,7 @@ class ElementBlogPostsTest extends SapphireTest
      * @param DataList $actual
      * @param string $message
      */
-    private function compareList(DataList $expected, DataList $actual, $message = '')
+    private function compareList(DataList $expected, DataList $actual, $message = ''): void
     {
         $expectedArray = $expected->map('ID', 'ClassName')->toArray();
         $actualArray = $expected->map('ID', 'ClassName')->toArray();


### PR DESCRIPTION
* We technically already required PHP `7.4` as we have some return type declarations that are only supported in PHP `>=7.4`.
* Minor linting/tidy-up to add type hints where PHP `7.4` allows, and where it wouldn't break our public API.