### PR TITLE
Fix null pointer exception in ElementBlogPosts Categories() call

### DIFF
--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -80,6 +80,7 @@ class ElementBlogPosts extends BaseElement
                         if ($blog) {
                             return $blog->Categories()->map('ID', 'Title');
                         }
+                        return [];
                     }
                     return [];
                 };

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -76,7 +76,10 @@ class ElementBlogPosts extends BaseElement
 
                 $dataSource = function ($val) {
                     if ($val) {
-                        return Blog::get()->byID($val)->Categories()->map('ID', 'Title');
+                        $blog = Blog::get()->byID($val);
+                        if ($blog) {
+                            return $blog->Categories()->map('ID', 'Title');
+                        }
                     }
                     return [];
                 };


### PR DESCRIPTION
## Summary
Fixes a critical null pointer exception that occurs when editing an ElementBlogPosts element with an invalid or deleted blog ID.

## Problem
The error occurs in `ElementBlogPosts.php` line 79:
```
[Emergency] Uncaught Error: Call to a member function Categories() on null
```

This happens when `Blog::get()->byID($val)` returns null (for non-existent blog IDs), but the code immediately calls `Categories()` on the result without checking if it's null.

## Solution
Added a null check for the blog object before calling the `Categories()` method:
- First retrieve the blog object with `$blog = Blog::get()->byID($val)`
- Check if the blog exists with `if ($blog)`
- Only call `Categories()` if the blog object is valid

## Changes
- Modified the `$dataSource` function in `ElementBlogPosts.php` to add proper null checking
- Maintains the same functionality while preventing fatal errors
- Returns empty array when blog is null, which is the expected fallback behavior

## Testing
This fix prevents the fatal error when:
1. An ElementBlogPosts element references a blog that has been deleted
2. An ElementBlogPosts element has an invalid blog ID
3. Editing the element in the CMS admin interface

The element will now gracefully handle missing blogs by returning an empty categories list instead of crashing.