### PR TITLE
Fix SS6 consistency issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,24 +23,18 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.1",
         "dnadesign/silverstripe-elemental": "^6.0",
         "sheadawson/silverstripe-dependentdropdownfield": "^4.0",
         "silverstripe/framework": "^6.0",
-        "silverstripe/blog": "^5.0"
+        "silverstripe/blog": "^5.1"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^4",
-        "silverstripe/widgets": "dev-feature/cms6-support",
+        "silverstripe/widgets": "^3.0",
         "squizlabs/php_codesniffer": "^3.0",
         "silverstripe/standards": "^1"
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "git@github.com:ishannz/silverstripe-widgets.git"
-        }
-    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
@@ -60,5 +54,10 @@
     "scripts": {
         "lint": "vendor/bin/phpcs src/ tests/",
         "lint-clean": "vendor/bin/phpcbf src/ tests/"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "4.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Follow-up to PR #50 to ensure SS6 consistency across all Dynamic modules.

## Changes

- Updated PHP requirement to `^8.1` (standard for all SS6 modules for maximum compatibility)
- Updated `silverstripe/blog` to `^5.1` (consistent with main installer)
- Use stable `silverstripe/widgets ^3.0` instead of fork
- Added branch-alias to dev-master

## Notes

This aligns with the SS6 upgrade patterns established in other Dynamic modules and ensures consistency across the codebase.