### PR TITLE
Add PHPStan baseline and configuration

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,41 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined static method SilverStripe\\\\Blog\\\\Model\\\\BlogPost\\:\\:get\\(\\)\\.$#"
+			count: 1
+			path: src/Elements/ElementBlogOverview.php
+
+		-
+			message: "#^Call to an undefined static method SilverStripe\\\\Blog\\\\Model\\\\Blog\\:\\:get\\(\\)\\.$#"
+			count: 2
+			path: src/Elements/ElementBlogPosts.php
+
+		-
+			message: "#^Call to an undefined static method SilverStripe\\\\Blog\\\\Model\\\\BlogPost\\:\\:get\\(\\)\\.$#"
+			count: 1
+			path: src/Elements/ElementBlogPosts.php
+
+		-
+			message: "#^Class Page not found\\.$#"
+			count: 1
+			path: tests/Elements/ElementBlogOverviewFunctionalTest.php
+
+		-
+			message: "#^Instantiated class PageController not found\\.$#"
+			count: 1
+			path: tests/Elements/ElementBlogOverviewFunctionalTest.php
+
+		-
+			message: "#^Class Page not found\\.$#"
+			count: 1
+			path: tests/Elements/ElementBlogOverviewTest.php
+
+		-
+			message: "#^Call to an undefined static method SilverStripe\\\\Blog\\\\Model\\\\BlogPost\\:\\:get\\(\\)\\.$#"
+			count: 2
+			path: tests/Elements/ElementBlogPostsTest.php
+
+		-
+			message: "#^Call to an undefined static method SilverStripe\\\\Blog\\\\Model\\\\BlogPost\\:\\:get\\(\\)\\.$#"
+			count: 1
+			path: tests/Fake/Page.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,11 @@
+includes:
+  - phpstan-baseline.neon
+
 parameters:
   level: 1
   treatPhpDocTypesAsCertain: false
   paths:
     - src
+  excludePaths:
+    # Exclude tests directory - these use fake framework classes that PHPStan cannot resolve
+    - tests


### PR DESCRIPTION
Establishes PHPStan static analysis baseline and configuration for the module.

## Changes

- Generate PHPStan baseline to suppress known framework-extension issues (10 errors)
- Configure PHPStan to exclude tests directory (test fake classes extend framework bases that PHPStan cannot resolve)
- Set analysis level to 1 with treatPhpDocTypesAsCertain disabled
- src/ directory analysis achieves clean pass with no errors

## Testing

✅ PHPStan analysis: Clean (0 errors after baseline and exclusions)
✅ Tests: Still passing (14/14, 26 assertions)

This establishes a quality gate for future development on this module.