### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Elements/ElementBlogOverview.php
+++ b/src/Elements/ElementBlogOverview.php
@@ -37,9 +37,9 @@ class ElementBlogOverview extends BaseElement
 
     private static string $table_name = 'ElementBlogOverview';
 
-    private static string $singular_name = 'Element blog overview';
+    private static string $singular_name = 'Blog Overview';
 
-    private static string $plural_name = 'Element blog overview blocks';
+    private static string $plural_name = 'Blog Overview Blocks';
 
     private static string $description = 'Block displaying Blog Posts with pagination';
 
@@ -140,15 +140,6 @@ class ElementBlogOverview extends BaseElement
      * @var string|null
      */
     private $cacheKey;
-
-    /**
-     * @codeCoverageIgnore
-     * @return string
-     */
-    public function getType(): string
-    {
-        return static::config()->get('default_title');
-    }
 
     /**
      * @codeCoverageIgnore

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -34,6 +34,10 @@ class ElementBlogPosts extends BaseElement
 
     private static string $table_name = 'ElementBlogPosts';
 
+    private static string $singular_name = 'Blog Posts';
+
+    private static string $plural_name = 'Blog Posts Blocks';
+
     private static array $db = [
         'Limit' => 'Int',
         'Content' => 'HTMLText',

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -146,12 +146,4 @@ class ElementBlogPosts extends BaseElement
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
     }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Blog Posts');
-    }
 }


### PR DESCRIPTION
## Summary

Remove the `getType()` method overrides from `ElementBlogPosts` and `ElementBlogOverview` so the elements inherit `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementBlogPosts`
- Removed the `getType()` method from `ElementBlogOverview`
- Updated `ElementBlogOverview::$singular_name` from `'Element blog overview'` to `'Blog Overview'` for better consistency with other elements

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the overrides, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #59

Related: dynamic/silverstripe-essentials-tools#68