### PR TITLE
Merge SS5 branch (3) into SS6 branch (4)

### DIFF
--- a/src/Elements/ElementBlogOverview.php
+++ b/src/Elements/ElementBlogOverview.php
@@ -37,9 +37,9 @@ class ElementBlogOverview extends BaseElement
 
     private static string $table_name = 'ElementBlogOverview';
 
-    private static string $singular_name = 'Element blog overview';
+    private static string $singular_name = 'Blog Overview';
 
-    private static string $plural_name = 'Element blog overview blocks';
+    private static string $plural_name = 'Blog Overview Blocks';
 
     private static string $description = 'Block displaying Blog Posts with pagination';
 
@@ -140,15 +140,6 @@ class ElementBlogOverview extends BaseElement
      * @var string|null
      */
     private $cacheKey;
-
-    /**
-     * @codeCoverageIgnore
-     * @return string
-     */
-    public function getType(): string
-    {
-        return static::config()->get('default_title');
-    }
 
     /**
      * @codeCoverageIgnore

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -34,6 +34,10 @@ class ElementBlogPosts extends BaseElement
 
     private static string $table_name = 'ElementBlogPosts';
 
+    private static string $singular_name = 'Blog Posts';
+
+    private static string $plural_name = 'Blog Posts Blocks';
+
     private static array $db = [
         'Limit' => 'Int',
         'Content' => 'HTMLText',
@@ -145,13 +149,5 @@ class ElementBlogPosts extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Blog Posts');
     }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`
- Added `$singular_name` and `$plural_name` properties

## Related

- Original SS5 PR: #60
- Parent issue: dynamic/silverstripe-essentials-tools#68