### PR TITLE
fix: SS6 namespace moves — ValidationException, ValidationResult

### DIFF
--- a/src/Elements/ElementBlogOverview.php
+++ b/src/Elements/ElementBlogOverview.php
@@ -13,7 +13,7 @@ use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Model\List\PaginatedList;
 use SilverStripe\ORM\DataList;
-use SilverStripe\ORM\ValidationException;
+use SilverStripe\Core\Validation\ValidationException;
 
 /**
  * Class ElementBlogOverview

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -14,7 +14,7 @@ use SilverStripe\Model\List\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Core\Validation\ValidationResult;
 
 /**
  * Class ElementBlogPosts


### PR DESCRIPTION
## Summary
- `SilverStripe\ORM\ValidationException` → `SilverStripe\Core\Validation\ValidationException` (ElementBlogOverview)
- `SilverStripe\ORM\ValidationResult` → `SilverStripe\Core\Validation\ValidationResult` (ElementBlogPosts)

Both classes moved in SilverStripe 6. Caught by PHPStan audit across the full Essentials suite.

## Test plan
- [ ] `ddev sake dev/build flush=1` passes (verified in testbed)
- [ ] PHPStan reports no errors on these files