### PR TITLE
fix(#66): Featured Blog field — replace TreeDropdownField with Blog-only DropdownField

### DIFF
--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -71,12 +71,14 @@ class ElementBlogPosts extends BaseElement
                 ->setTitle(_t(__CLASS__ . 'LimitLabel', 'Posts to show'));
 
             if (class_exists(Blog::class)) {
-                $fields->insertBefore(
-                    'Limit',
-                    $fields->dataFieldByName('BlogID')
-                        ->setTitle(_t(__CLASS__ . 'BlogLabel', 'Featured Blog'))
-                        ->setEmptyString('')
-                );
+                $blogField = DropdownField::create(
+                    'BlogID',
+                    _t(__CLASS__ . 'BlogLabel', 'Featured Blog'),
+                    Blog::get()->map('ID', 'Title')
+                )->setEmptyString('');
+
+                $fields->replaceField('BlogID', $blogField);
+                $fields->insertBefore('Limit', $blogField);
 
                 $dataSource = function ($val) {
                     if ($val) {
@@ -95,7 +97,7 @@ class ElementBlogPosts extends BaseElement
                         __CLASS__ . 'CategoryLabel',
                         'Category'
                     ), $dataSource)
-                        ->setDepends($fields->dataFieldByName('BlogID'))
+                        ->setDepends($blogField)
                         ->setHasEmptyDefault(true)
                         ->setEmptyString('')
                 );

--- a/src/Elements/ElementBlogPosts.php
+++ b/src/Elements/ElementBlogPosts.php
@@ -77,7 +77,6 @@ class ElementBlogPosts extends BaseElement
                     Blog::get()->map('ID', 'Title')
                 )->setEmptyString('');
 
-                $fields->replaceField('BlogID', $blogField);
                 $fields->insertBefore('Limit', $blogField);
 
                 $dataSource = function ($val) {

--- a/tests/Elements/ElementBlogPostsTest.php
+++ b/tests/Elements/ElementBlogPostsTest.php
@@ -6,7 +6,9 @@ use Dynamic\Elements\Blog\Elements\ElementBlogPosts;
 use SilverStripe\Blog\Model\BlogCategory;
 use SilverStripe\Blog\Model\BlogPost;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\DataList;
 
 class ElementBlogPostsTest extends SapphireTest
@@ -51,7 +53,19 @@ class ElementBlogPostsTest extends SapphireTest
         $object = $this->objFromFixture(ElementBlogPosts::class, 'one');
         $fields = $object->getCMSFields();
         $this->assertInstanceOf(FieldList::class, $fields);
-        $this->assertNotNull($fields->dataFieldByName('BlogID'));
+
+        $blogField = $fields->dataFieldByName('BlogID');
+        $this->assertNotNull($blogField, 'BlogID field should be present');
+        $this->assertInstanceOf(
+            DropdownField::class,
+            $blogField,
+            'Featured Blog should be a plain DropdownField, not a tree or searchable picker'
+        );
+        $this->assertNotInstanceOf(
+            TreeDropdownField::class,
+            $blogField,
+            'Featured Blog must not render as a TreeDropdownField (full-site page picker)'
+        );
     }
 
     /**

--- a/tests/Elements/ElementBlogPostsTest.php
+++ b/tests/Elements/ElementBlogPostsTest.php
@@ -8,7 +8,6 @@ use SilverStripe\Blog\Model\BlogPost;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\DataList;
 
 class ElementBlogPostsTest extends SapphireTest
@@ -56,15 +55,10 @@ class ElementBlogPostsTest extends SapphireTest
 
         $blogField = $fields->dataFieldByName('BlogID');
         $this->assertNotNull($blogField, 'BlogID field should be present');
-        $this->assertInstanceOf(
+        $this->assertSame(
             DropdownField::class,
-            $blogField,
-            'Featured Blog should be a plain DropdownField, not a tree or searchable picker'
-        );
-        $this->assertNotInstanceOf(
-            TreeDropdownField::class,
-            $blogField,
-            'Featured Blog must not render as a TreeDropdownField (full-site page picker)'
+            get_class($blogField),
+            'Featured Blog must be a plain DropdownField, not a tree picker or searchable subclass'
         );
     }
 


### PR DESCRIPTION
## Summary

- In SS6, `DataObject::scaffoldFormFieldForHasOne()` scaffolds a `has_one` to a `SiteTree` subclass as a **`TreeDropdownField`** over the whole site tree.
- `ElementBlogPosts::getCMSFields()` was reusing `dataFieldByName('BlogID')` and inheriting that full-site tree picker for the **Featured Blog** field.
- Users could pick any page (not just Blogs), and typing a search term in the tree picker errored on sites with a blog matching the search (reported: blog named "social").

## Changes

- **`src/Elements/ElementBlogPosts.php`** — replace the scaffolded field with an explicit `DropdownField` sourced from `Blog::get()->map('ID', 'Title')`. Only Blog pages appear; no AJAX search endpoint.
- **`tests/Elements/ElementBlogPostsTest.php`** — extend `testGetCMSFields()` to assert `DropdownField` (not `TreeDropdownField`).

## Test plan

- [x] `vendor/bin/phpunit vendor/dynamic/silverstripe-elemental-blog/tests` — 14/14 pass (1 pre-existing incomplete)
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/ tests/` — clean
- [x] Manual CMS verification: Featured Blog field is now a plain `<select>` listing only Blog pages; no tree, no search AJAX

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mihByrCZ8AjHwEfdPLCGi