### PR TITLE
chore(#70): remove stale branch-alias pointing at legacy master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,10 +52,5 @@
     "scripts": {
         "lint": "vendor/bin/phpcs src/ tests/",
         "lint-clean": "vendor/bin/phpcbf src/ tests/"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.0.x-dev"
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Removes \`extra.branch-alias\` (\`dev-master: 4.0.x-dev\`) — a leftover from the integer-branch migration. The \`4\` branch already resolves to \`4.x-dev\` on its own; the alias only made the stale legacy \`master\` branch a valid \`^4.0@dev\` candidate.

Closes #70

Found while auditing suite-wide composer.json VCS/alias plumbing (see essentials-ss6 audit, unrelated to the dnadesign/silverstripe-embed 2.0.0 release that prompted the check).

## Test plan
- [x] Resulting composer.json is valid JSON
- [ ] \`composer show dynamic/silverstripe-elemental-blog\` in a consumer still resolves to \`4.x-dev\`, not \`4.0.x-dev\`/legacy \`master\`